### PR TITLE
Moved kefir to peerDependencies:

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "codecov": "^1.0.1",
     "envify": "^4.0.0",
     "eslint": "^3.13.1",
+    "kefir": "^3.7.0",
     "mocha": "^3.2.0",
     "nyc": "^10.0.0",
     "ramda": "^0.23.0",
@@ -45,6 +46,8 @@
   },
   "dependencies": {
     "infestines": "^0.4.0",
+  },
+  "peerDependencies": {
     "kefir": "^3.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "uglifyify": "^3.0.4"
   },
   "dependencies": {
-    "infestines": "^0.4.0",
+    "infestines": "^0.4.0"
   },
   "peerDependencies": {
     "kefir": "^3.7.0"


### PR DESCRIPTION
- In order to ensure only one version of kefir is used within a project due to instanceof operations

We were running into issues where `instanceof Observable` operations were failing because of mismatching or multiple same versions (due to not doing empty npm install) of Kefir.

I moved `Kefir` to peerDependencies to ensure that kefir.combines uses same Kefir module.